### PR TITLE
Add support for RVZ and WIA file formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Enable ```best_match_game_detection``` to allow the best match algorithm. It can
 
 If you enable none of the above options the name of the ROM must be equivalent to its counterpart in GamesList.txt. You can look up the name in GamesList.txt and edit your file accordingly.
 
-Supported file extensions are ISO, CISO, GCM, GCZ, WAD and WBFS.
+Supported file extensions are ISO, CISO, GCM, GCZ, WAD, WBFS, WIA, and RVZ.

--- a/backend.py
+++ b/backend.py
@@ -66,7 +66,7 @@ class BackendClient:
         # Search through directory for Dolphin ROMs
         for root, _, files in os.walk(user_config.roms_path):
             for file in files:
-                if any(file.lower().endswith(ext) for ext in (".iso", ".ciso", ".gcm", ".gcz", ".wad", ".wbfs")):
+                if any(file.lower().endswith(ext) for ext in (".iso", ".ciso", ".gcm", ".gcz", ".wad", ".wbfs", ".wia", ".rvz")):
                     paths.append(os.path.join(root, file))
         return paths
 


### PR DESCRIPTION
as of Dolphin version 5.0-12188, Dolphin can load and convert to WIA and RVZ file formats. this PR adds support for those